### PR TITLE
Fix mistaken apostrophe meant to indicate plural

### DIFF
--- a/doc/vim-stay.txt
+++ b/doc/vim-stay.txt
@@ -154,7 +154,7 @@ You have removed "folds" from 'viewoptions'. See the recommended setting
 under |vim-stay-viewoptions|.
 
 
-MY STATE IS NOT PERSISTED WHEN SWITCHING BETWEEN WINDOWS AND OTHER OS'
+MY STATE IS NOT PERSISTED WHEN SWITCHING BETWEEN WINDOWS AND OTHER OSes
 
 With the default settings, 'viewoptions' uses platform specific path
 separators, which means stored view sessions are not portable. See the


### PR DESCRIPTION
OS' is the possessive form used to indicate something that belongs to the OS, like, 'The OS' task scheduler was complete rubbish.' OSes is IMO the best option.
